### PR TITLE
coord: make coords unsigned

### DIFF
--- a/conway/conway.go
+++ b/conway/conway.go
@@ -13,18 +13,18 @@ type Animator interface {
 // Grid represents an inmutable snapshot of a universe.
 type Grid interface {
 	// Width returns the width of the universe (number of cells).
-	Width() int
+	Width() uint
 	// Height returns the height of the universe (number of cells).
-	Height() int
+	Height() uint
 	// IsAlive returns if the cell at coordinates x, y is alive.
 	// Returns an error if x or y are out of bounds.
 	IsAlive(Coord) (bool, error)
 }
 
-// Coord identifies a cell in a 2D coordinate grid.
+// Coord represents the position of a cell in a grid.
 type Coord interface {
-	// X returns the abscissa.
-	X() int
-	// Y returns the ordinate.
-	Y() int
+	// X returns the cell's abscissa.
+	X() uint
+	// Y returns the cell's ordinate.
+	Y() uint
 }

--- a/grid/grid.go
+++ b/grid/grid.go
@@ -10,7 +10,7 @@ import (
 // The zero value of this type is not safe, use the function New below.
 // The minimum width and height for a universe is 3 cells each.
 type Grid struct {
-	width, height int
+	width, height uint
 	cells         []bool // true means alive
 }
 
@@ -23,7 +23,7 @@ const (
 // and the given list of alive cells.
 // Returns an error if the width or the height is smaller than 3 or if any
 // of the alive cells are out of bounds.
-func New(width, height int, alives []conway.Coord) (*Grid, error) {
+func New(width, height uint, alives []conway.Coord) (*Grid, error) {
 	if width < minWidth {
 		return nil, fmt.Errorf("width must be >= than %d, was %d",
 			minWidth, width)
@@ -56,18 +56,18 @@ func (g *Grid) pos(c conway.Coord) (int, error) {
 		return 0, fmt.Errorf("ordinate value too high (%d) for grid (height = %d)",
 			c.Y(), g.Height())
 	}
-	return c.Y()*g.Width() + c.X(), nil
+	return int(c.Y()*g.Width() + c.X()), nil
 }
 
 // Width returns the width of the universe (number of cells).
 // Implements conway.Grid.
-func (g *Grid) Width() int {
+func (g *Grid) Width() uint {
 	return g.width
 }
 
 // Height returns the height of the universe (number of cells).
 // Implements conway.Grid.
-func (g *Grid) Height() int {
+func (g *Grid) Height() uint {
 	return g.height
 }
 

--- a/grid/grid_test.go
+++ b/grid/grid_test.go
@@ -17,7 +17,7 @@ func TestSizeOK(t *testing.T) {
 	testSizeOK(t, 10000, 20000)
 }
 
-func testSizeOK(t *testing.T, width, height int) {
+func testSizeOK(t *testing.T, width, height uint) {
 	t.Helper()
 	g, err := grid.New(width, height, nil)
 	if err != nil {
@@ -36,13 +36,9 @@ func TestSizeError(t *testing.T) {
 	testSizeError(t, 3, 2)
 	testSizeError(t, 2, 2)
 	testSizeError(t, 0, 0)
-	testSizeError(t, -6, 3)
-	testSizeError(t, 3, -6)
-	testSizeError(t, 10000, -2)
-	testSizeError(t, -2, 10000)
 }
 
-func testSizeError(t *testing.T, width, height int) {
+func testSizeError(t *testing.T, width, height uint) {
 	t.Helper()
 	_, err := grid.New(width, height, nil)
 	if err == nil {


### PR DESCRIPTION
To avoid checking everywhere for negative numbers.